### PR TITLE
Dynamic graph generation for dFlow

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -70,7 +70,11 @@ $(function() {
         url: `${THE_ORG_BOOK_APP_URL}/api/credential/${walletId}`,
         contentType: "application/json"
       }).done(function(response) {
-        window.location = `/demo?topic=${response.topic}`
+        // retrieve queryparams defining the target credentials from the URL before returning to dFlow
+        const schema_name = window.location.href.split('&')[1].split('=')[1];
+        const schema_version = window.location.href.split('&')[2].split('=')[1];
+        const issuer_did = window.location.href.split('&')[3].split('=')[1];
+        window.location = `/demo?topic=${response.topic}&name=${schema_name}&version=${schema_version}&did=${issuer_did}`
       });
     });
   });

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -29,37 +29,31 @@
 
     proxy /bcreg {%BCREG_AGENT_HOST%}:{%BCREG_AGENT_PORT%} {
         except /assets
-        # health_check /health  # return 502 bad gateway if not synced
         transparent
     }
 
     proxy /finance {%MINISTRY_FINANCE_AGENT_HOST%}:{%MINISTRY_FINANCE_AGENT_PORT%} {
         except /assets
-        # health_check /health  # return 502 bad gateway if not synced
         transparent
     }
 
     proxy /surrey {%CITY_SURREY_AGENT_HOST%}:{%CITY_SURREY_AGENT_PORT%} {
         except /assets
-        # health_check /health  # return 502 bad gateway if not synced
         transparent
     }
 
     proxy /fraser-valley {%FRASER_VALLEY_AGENT_HOST%}:{%FRASER_VALLEY_AGENT_PORT%} {
         except /assets
-        # health_check /health  # return 502 bad gateway if not synced
         transparent
     }
 
     proxy /liquor {%LIQUOR_CONTROL_AGENT_HOST%}:{%LIQUOR_CONTROL_AGENT_PORT%} {
         except /assets
-        # health_check /health  # return 502 bad gateway if not synced
         transparent
     }
 
     proxy /worksafe {%WORKSAFE_AGENT_HOST%}:{%WORKSAFE_AGENT_PORT%} {
         except /assets
-        # health_check /health  # return 502 bad gateway if not synced
         transparent
     }
 }

--- a/config/bcreg-agent/services.yml
+++ b/config/bcreg-agent/services.yml
@@ -198,11 +198,11 @@ issuers:
 
 # proof_requests:
 #   registration:
-#     version: '1.0.4'
+#     version: '1.0.5'
 #     schemas:
 #       - key:
 #           name: registration.permitify
-#           version: '1.0.4'
+#           version: '1.0.5'
 #         attributes:
 #           - corp_num
 #           - address_line_1

--- a/config/bcreg-agent/services.yml
+++ b/config/bcreg-agent/services.yml
@@ -3,8 +3,6 @@ issuers:
     logo_path: ''
     name: BC Corporate Registry
     abbreviation: BCReg
-    url: "https://www2.gov.bc.ca/gov/content/governments/organizational-structure/\
-      ministries-organizations/ministries/citizens-services/bc-registries-online-services"
     email: bcreg.test.issuer@example.ca
     url: $APPLICATION_URL_INCORP
     endpoint: ${ENDPOINT_URL}/bcreg

--- a/config/city-surrey-agent/services.yml
+++ b/config/city-surrey-agent/services.yml
@@ -54,48 +54,48 @@ verifiers:
 
 proof_requests:
   registration:
-    version: '1.0.4'
+    version: '1.0.5'
     schemas:
       - key:
           did: 6qnvgJtqwK44D8LFYnV5Yf
           name: registration.permitify
-          version: '1.0.4'
+          version: '1.0.5'
         attributes:
           - corp_num
           - legal_name
   pst-number:
-    version: '1.0.4'
+    version: '1.0.5'
     schemas:
       - key:
           did: CYnWiuEtJJuhpWvVz3kY9D
           name: pst_number.permitify
-          version: '1.0.4'
+          version: '1.0.5'
         attributes:
           - corp_num
   clearance-letter:
-    version: '1.0.4'
+    version: '1.0.5'
     schemas:
       - key:
           did: MAcounf9HxhgnqqhzReTLC
           name: worksafe.permitify
-          version: '1.0.4'
+          version: '1.0.5'
         attributes:
           - corp_num
   operating-permit:
-    version: '1.0.4'
+    version: '1.0.5'
     schemas:
       - key:
           did: L6SJy7gNRCLUp8dV94hfex
           name: operating_permit.permitify
-          version: '1.0.4'
+          version: '1.0.5'
         attributes:
           - corp_num
   liquor-license:
-    version: '1.0.4'
+    version: '1.0.5'
     schemas:
       - key:
           did: ScrMddP9C426QPrp1KViZB
           name: liquor_license.permitify
-          version: '1.0.4'
+          version: '1.0.5'
         attributes:
           - corp_num

--- a/config/city-surrey-agent/services.yml
+++ b/config/city-surrey-agent/services.yml
@@ -33,7 +33,7 @@ issuers:
         schema: biz_license.permitify
         issuer_url: $APPLICATION_URL_INCORP
         depends_on:
-        - liquor-license
+          - liquor-license
         topic:
           source_id:
             input: corp_num

--- a/config/fraser-valley-agent/services.yml
+++ b/config/fraser-valley-agent/services.yml
@@ -33,7 +33,7 @@ issuers:
         schema: operating_permit.permitify
         issuer_url: $APPLICATION_URL_INCORP
         depends_on:
-        - clearance-letter
+          - clearance-letter
         topic:
           source_id:
             input: corp_num

--- a/config/fraser-valley-agent/services.yml
+++ b/config/fraser-valley-agent/services.yml
@@ -41,18 +41,6 @@ issuers:
           type:
             input: registration
             from: value
-
-proof_requests:
-  registration:
-    version: '1.0.4'
-    schemas:
-      - key:
-          did: 6qnvgJtqwK44D8LFYnV5Yf
-          name: registration.permitify
-          version: '1.0.4'
-        attributes:
-          - corp_num
-
 verifiers:
   bctob:
     name: BC OrgBook
@@ -64,21 +52,21 @@ verifiers:
 
 proof_requests:
   registration:
-    version: '1.0.4'
+    version: '1.0.5'
     schemas:
       - key:
           did: 6qnvgJtqwK44D8LFYnV5Yf
           name: registration.permitify
-          version: '1.0.4'
+          version: '1.0.5'
         attributes:
           - corp_num
           - legal_name
   clearance-letter:
-    version: '1.0.4'
+    version: '1.0.5'
     schemas:
       - key:
           did: MAcounf9HxhgnqqhzReTLC
           name: worksafe.permitify
-          version: '1.0.4'
+          version: '1.0.5'
         attributes:
           - corp_num

--- a/config/liquor-control-agent/services.yml
+++ b/config/liquor-control-agent/services.yml
@@ -33,8 +33,8 @@ issuers:
         schema: liquor_license.permitify
         issuer_url: $APPLICATION_URL_INCORP
         depends_on:
-        - pst-number
-        - operating-permit
+          - pst-number
+          - operating-permit
         topic:
           source_id:
             input: corp_num

--- a/config/liquor-control-agent/services.yml
+++ b/config/liquor-control-agent/services.yml
@@ -54,39 +54,39 @@ verifiers:
 
 proof_requests:
   registration:
-    version: '1.0.4'
+    version: '1.0.5'
     schemas:
       - key:
           did: 6qnvgJtqwK44D8LFYnV5Yf
           name: registration.permitify
-          version: '1.0.4'
+          version: '1.0.5'
         attributes:
           - corp_num
           - legal_name
   pst-number:
-    version: '1.0.4'
+    version: '1.0.5'
     schemas:
       - key:
           did: CYnWiuEtJJuhpWvVz3kY9D
           name: pst_number.permitify
-          version: '1.0.4'
+          version: '1.0.5'
         attributes:
           - corp_num
   clearance-letter:
-    version: '1.0.4'
+    version: '1.0.5'
     schemas:
       - key:
           did: MAcounf9HxhgnqqhzReTLC
           name: worksafe.permitify
-          version: '1.0.4'
+          version: '1.0.5'
         attributes:
           - corp_num
   operating-permit:
-    version: '1.0.4'
+    version: '1.0.5'
     schemas:
       - key:
           did: L6SJy7gNRCLUp8dV94hfex
           name: operating_permit.permitify
-          version: '1.0.4'
+          version: '1.0.5'
         attributes:
           - corp_num

--- a/config/ministry-finance-agent/services.yml
+++ b/config/ministry-finance-agent/services.yml
@@ -53,12 +53,12 @@ verifiers:
 
 proof_requests:
   registration:
-    version: '1.0.4'
+    version: '1.0.5'
     schemas:
       - key:
           did: 6qnvgJtqwK44D8LFYnV5Yf
           name: registration.permitify
-          version: '1.0.4'
+          version: '1.0.5'
         attributes:
           - corp_num
           # - address_line_1

--- a/config/worksafe-agent/services.yml
+++ b/config/worksafe-agent/services.yml
@@ -33,7 +33,7 @@ issuers:
         schema: worksafe.permitify
         issuer_url: $APPLICATION_URL_INCORP
         depends_on:
-        - registration
+          - registration
         topic:
           source_id:
             input: corp_num

--- a/config/worksafe-agent/services.yml
+++ b/config/worksafe-agent/services.yml
@@ -53,12 +53,12 @@ verifiers:
 
 proof_requests:
   registration:
-    version: '1.0.4'
+    version: '1.0.5'
     schemas:
       - key:
           did: 6qnvgJtqwK44D8LFYnV5Yf
           name: registration.permitify
-          version: '1.0.4'
+          version: '1.0.5'
         attributes:
           - corp_num
           # - address_line_1

--- a/dflow-demo/package-lock.json
+++ b/dflow-demo/package-lock.json
@@ -4339,7 +4339,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4754,7 +4755,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4810,6 +4812,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4853,12 +4856,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/dflow-demo/package-lock.json
+++ b/dflow-demo/package-lock.json
@@ -4360,12 +4360,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4380,17 +4382,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4507,7 +4512,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4519,6 +4525,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4533,6 +4540,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4540,12 +4548,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4564,6 +4574,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4644,7 +4655,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4656,6 +4668,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4777,6 +4790,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/dflow-demo/src/app/app.module.ts
+++ b/dflow-demo/src/app/app.module.ts
@@ -9,6 +9,7 @@ import { HeaderComponent } from './components/header/header.component';
 import { HomeComponent } from './components/home/home.component';
 import { RecipeComponent } from './components/recipe/recipe.component';
 import { WorkflowStepComponent } from './components/workflow/workflow-step/workflow-step.component';
+import { FormsModule } from '@angular/forms';
 
 
 
@@ -27,6 +28,7 @@ import { WorkflowStepComponent } from './components/workflow/workflow-step/workf
   imports: [
     AppRoutingModule,
     BrowserModule,
+    FormsModule,
     HttpClientModule,
     NgbModule
   ],

--- a/dflow-demo/src/app/components/home/home.component.html
+++ b/dflow-demo/src/app/components/home/home.component.html
@@ -4,7 +4,7 @@
   </h1>
 
   <p>
-    Please select the issuer/credential you would like to obtain from the following list:
+    Please select the credential you would like to obtain:
   </p>
 
   <div class="form-group">

--- a/dflow-demo/src/app/components/home/home.component.html
+++ b/dflow-demo/src/app/components/home/home.component.html
@@ -2,5 +2,17 @@
   <h1>
       dFlow Demo
   </h1>
-  <a href="/bcreg/incorporation" class="btn btn-lg btn-primary">Begin</a>
+
+  <p>
+    Please select the issuer/credential you would like to obtain from the following list:
+  </p>
+
+  <select class="form-control" [(ngModel)]="selectedCred">
+    <option value="undefined">Select a credential</option>
+    <option *ngFor="let cred of availableCreds" [ngValue]="cred">
+      {{ cred.issuer.name }} - {{ cred.schema.name }}
+    </option>
+  </select>
+
+  <button class="btn btn-lg  btn-primary" type="button" (click)="doSomething()">Begin</button>
 </main>

--- a/dflow-demo/src/app/components/home/home.component.html
+++ b/dflow-demo/src/app/components/home/home.component.html
@@ -7,12 +7,16 @@
     Please select the issuer/credential you would like to obtain from the following list:
   </p>
 
-  <select class="form-control" [(ngModel)]="selectedCred">
-    <option value="undefined">Select a credential</option>
-    <option *ngFor="let cred of availableCreds" [ngValue]="cred">
-      {{ cred.issuer.name }} - {{ cred.schema.name }}
-    </option>
-  </select>
+  <div class="form-group">
+    <label class="control-label" for="credPicker">Credential:</label>
+    <select id="credPicker" class="form-control col-md-6" [(ngModel)]="selectedCred">
+      <option value="undefined">Select a credential</option>
+      <option *ngFor="let cred of availableCreds" [ngValue]="cred">
+        {{ cred.issuer.name }} - {{ cred.schema.name }}
+      </option>
+    </select>
+    <div class="invalid-feedback" *ngIf="error">Please pick an issuer/schema combination to proceed.</div>
+  </div>
 
-  <button class="btn btn-lg  btn-primary" type="button" (click)="doSomething()">Begin</button>
+  <button class="btn btn-primary" type="button" (click)="begin()">Begin</button>
 </main>

--- a/dflow-demo/src/app/components/home/home.component.scss
+++ b/dflow-demo/src/app/components/home/home.component.scss
@@ -1,0 +1,3 @@
+.invalid-feedback {
+  display: block;
+}

--- a/dflow-demo/src/app/components/home/home.component.ts
+++ b/dflow-demo/src/app/components/home/home.component.ts
@@ -1,5 +1,12 @@
 import { Component, OnInit } from '@angular/core';
 
+import { forkJoin } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+import { TobService } from '../../services/tob.service';
+import { Schema } from '../../models/schema';
+import { Issuer } from 'src/app/models/issuer';
+
 @Component({
   selector: 'app-home',
   templateUrl: './home.component.html',
@@ -7,9 +14,38 @@ import { Component, OnInit } from '@angular/core';
 })
 export class HomeComponent implements OnInit {
 
-  constructor() { }
+  availableCreds: Array<any>;
+  selectedCred: any;
+
+  constructor( private tobService: TobService ) {
+    this.availableCreds = new Array<any>();
+   }
 
   ngOnInit() {
+    const getIssuers = this.tobService.getIssuers();
+    const getSchemas = this.tobService.getLatestSchemas();
+
+    forkJoin(getIssuers, getSchemas).subscribe((data) => {
+      const issuers = data[0] as any;
+      const schemas = data[1] as any;
+
+      schemas.results.forEach(schema => {
+        const schema_obj = new Schema(schema);
+        const schemaIssuer = issuers.results.filter((issuer) => {
+          const issuer_obj = new Issuer(issuer);
+          return schema_obj.origin_did === issuer.did;
+        });
+        this.availableCreds.push({
+          issuer: schemaIssuer[0],
+          schema: schema_obj
+        });
+      });
+
+      console.log(this.availableCreds);
+    });
   }
 
+  doSomething() {
+    console.log(this.selectedCred.schema.name);
+  }
 }

--- a/dflow-demo/src/app/components/home/home.component.ts
+++ b/dflow-demo/src/app/components/home/home.component.ts
@@ -6,6 +6,7 @@ import { map } from 'rxjs/operators';
 import { TobService } from '../../services/tob.service';
 import { Schema } from '../../models/schema';
 import { Issuer } from 'src/app/models/issuer';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-home',
@@ -16,8 +17,11 @@ export class HomeComponent implements OnInit {
 
   availableCreds: Array<any>;
   selectedCred: any;
+  error = false;
 
-  constructor( private tobService: TobService ) {
+  constructor(
+    private tobService: TobService,
+    private router: Router ) {
     this.availableCreds = new Array<any>();
    }
 
@@ -45,7 +49,16 @@ export class HomeComponent implements OnInit {
     });
   }
 
-  doSomething() {
-    console.log(this.selectedCred.schema.name);
+  begin() {
+    if (!this.selectedCred) {
+      // don't proceed if a credential is not selected
+      this.error = true;
+    } else {
+      this.error = false;
+
+      const url = `/demo?name=${this.selectedCred.schema.name}&version=${this.selectedCred.schema.version}&did=${this.selectedCred.schema.origin_did}`;
+
+      this.router.navigateByUrl(url);
+    }
   }
 }

--- a/dflow-demo/src/app/components/recipe/recipe.component.ts
+++ b/dflow-demo/src/app/components/recipe/recipe.component.ts
@@ -17,8 +17,16 @@ import { map } from 'rxjs/operators';
 export class RecipeComponent implements OnInit, AfterViewInit {
 
   @ViewChild('canvasRoot') svgRoot;
-  issuers: Array<Issuer>;
+
   topic: number;
+  targetName: string;
+  targetVersion: string;
+  targetDid: string;
+
+  issuers: Array<Issuer>;
+  nodes: any;
+  links: any;
+
   credentials: any;
   walletId: string;
   graphLayout: Promise<any>;
@@ -34,30 +42,43 @@ export class RecipeComponent implements OnInit, AfterViewInit {
   ngOnInit() {
     // get topicId from route
     this.activatedRoute.queryParams.subscribe((params) => {
+      this.targetName = params['name'];
+      this.targetVersion = params['version'];
+      this.targetDid = params['did'];
+
       this.topic = params['topic'];
-      // create a promise that will be resolved once the graph is ready to be rendered
-      // start with retrieving all the credentials that have been issued so far
-      this.graphLayout = this.tobService.getCredentialsByTopic(this.topic).toPromise()
-      .then((creds) => {
-        console.log('Credentials:', creds);
-        this.credentials = creds;
-        this.walletId = this.getWalletId();
-        // get issuer list
-        return this.tobService.getIssuers().toPromise();
-      }).then((data: any) => {
-        console.log('Issuers:', data);
-        data.results.forEach(element => {
-          this.issuers.push(new Issuer(element));
+
+      this.graphLayout = this.tobService.getIssuers().toPromise()
+      .then((issuers: any) => {
+        console.log('Issuers:', issuers);
+        issuers.results.forEach(issuer => {
+          this.issuers.push(new Issuer(issuer));
         });
       }).then(() => {
         // get topology and set-up graphing library
-        return this.tobService.getPathToStep("biz_license.permitify", "1.0.4", "A9Rsuu7FNquw8Ne2Smu5Nr").toPromise();
-      }).then((result: any) => {
-        console.log('Path:', result);
+        return this.tobService.getPathToStep(this.targetName, this.targetVersion, this.targetDid).toPromise();
+      }).then((topology: any) => {
+        console.log('Path:', topology);
+        // store topology
+        this.nodes = topology.result.nodes;
+        this.links = topology.result.links;
+      }).then(() => {
+        // grab the credentials if we already have a topic, otherwise return an empty array
+        if (this.topic) {
+          return this.tobService.getCredentialsByTopic(this.topic).toPromise();
+        } else {
+          return new Array<any>();
+        }
+      })
+      .then((creds: any) => {
+        console.log('Credentials:', creds);
+        this.credentials = creds;
+        this.walletId = this.getWalletId();
+
         // add nodes
-        result.result.nodes.forEach(node => {
+        this.nodes.forEach(node => {
           const issuer = this.tobService.getIssuerByDID(node.origin_did, this.issuers);
-          const deps = this.tobService.getDependenciesByID(node.id, result.result.links, this.credentials, this.issuers);
+          const deps = this.tobService.getDependenciesByID(node.id, this.links, this.credentials, this.issuers);
           const credData = this.availableCredForIssuer(issuer);
           const step = new Step(this.topic, this.walletId, node.schema_name, deps, issuer, credData);
           const nodeHTML = this.nodeResolverService.getHTMLForNode(step);
@@ -65,11 +86,11 @@ export class RecipeComponent implements OnInit, AfterViewInit {
         });
 
         // add links
-        result.result.links.forEach(link => {
+        this.links.forEach(link => {
           this.workflowService.addLink(new WorkflowLink(link.target, link.source));
         });
       });
-    });
+    })
   }
 
   ngAfterViewInit() {
@@ -98,7 +119,7 @@ export class RecipeComponent implements OnInit, AfterViewInit {
 
   private getWalletId() {
     let walletId = undefined;
-    if (this.credentials) {
+    if (this.credentials && this.credentials.length > 0) {
       walletId = this.credentials[0].wallet_id;
     }
     return walletId;

--- a/dflow-demo/src/app/components/recipe/recipe.component.ts
+++ b/dflow-demo/src/app/components/recipe/recipe.component.ts
@@ -7,7 +7,6 @@ import { WorkflowService } from 'src/app/services/workflow.service';
 import { Step } from '../../models/step';
 import { NodeLabelType, WorkflowNode } from '../../models/workflow-node';
 import { TobService } from '../../services/tob.service';
-import { map } from 'rxjs/operators';
 
 @Component({
   selector: 'app-recipe',
@@ -80,7 +79,19 @@ export class RecipeComponent implements OnInit, AfterViewInit {
           const issuer = this.tobService.getIssuerByDID(node.origin_did, this.issuers);
           const deps = this.tobService.getDependenciesByID(node.id, this.links, this.credentials, this.issuers);
           const credData = this.availableCredForIssuer(issuer);
-          const step = new Step(this.topic, this.walletId, node.schema_name, deps, issuer, credData);
+          const step = new Step({
+            topicId: this.topic,
+            walletId: this.walletId,
+            stepName: node.schema_name,
+            dependencies: deps,
+            issuer: issuer,
+            credData: credData,
+            schema : {
+              name: this.targetName,
+              version: this.targetVersion,
+              did: this.targetDid
+            }
+          });
           const nodeHTML = this.nodeResolverService.getHTMLForNode(step);
           this.workflowService.addNode(new WorkflowNode(node.id, nodeHTML, NodeLabelType.HTML));
         });

--- a/dflow-demo/src/app/components/recipe/recipe.component.ts
+++ b/dflow-demo/src/app/components/recipe/recipe.component.ts
@@ -51,7 +51,7 @@ export class RecipeComponent implements OnInit, AfterViewInit {
         });
       }).then(() => {
         // get topology and set-up graphing library
-        return this.tobService.getPathToStep().toPromise();
+        return this.tobService.getPathToStep("biz_license.permitify", "1.0.4", "A9Rsuu7FNquw8Ne2Smu5Nr").toPromise();
       }).then((result: any) => {
         console.log('Path:', result);
         // add nodes

--- a/dflow-demo/src/app/components/workflow/workflow-step/workflow-step.component.ts
+++ b/dflow-demo/src/app/components/workflow/workflow-step/workflow-step.component.ts
@@ -40,7 +40,9 @@ export class WorkflowStepComponent implements OnInit {
       this.actionTarget = '_blank';
     } else if (this.isStart || this.allDepsSatisfied) {
       this.actionTxt = `Enroll with ${this.step.issuer.name}`;
-      this.actionURL = `${this.step.issuer.url}?credential_ids=${this.step.walletId}`;
+      const credentialParam = `credential_ids=${this.step.walletId}`;
+      const schemaParam = `schema_name=${this.step.requestedSchema.name}&schema_version=${this.step.requestedSchema.version}&issuer_did=${this.step.requestedSchema.did}`;
+      this.actionURL = `${this.step.issuer.url}?${credentialParam}&${schemaParam}`;
       this.actionTarget = '_self'
     } else {
       this.actionTxt = 'Dependencies not met';

--- a/dflow-demo/src/app/models/schema.ts
+++ b/dflow-demo/src/app/models/schema.ts
@@ -1,0 +1,17 @@
+export class Schema {
+  id: number;
+  create_timestamp: string;
+  update_timestamp: string;
+  name: string;
+  version: string;
+  origin_did: string
+
+  constructor(schema: any) {
+    this.id = schema.id;
+    this.create_timestamp = schema.create_timestamp;
+    this.update_timestamp = schema.update_timestamp;
+    this.name = schema.name;
+    this.version = schema.version;
+    this.origin_did = schema.origin_did;
+  }
+}

--- a/dflow-demo/src/app/models/step.ts
+++ b/dflow-demo/src/app/models/step.ts
@@ -11,27 +11,33 @@ export class Step {
   effectiveDate: string;
   credentialId: number;
   walletId: string;
+  // TODO: refactor requestedschema out of the step, if possible
+  requestedSchema: any;
 
   // computed
   actionText: string;
   actionURL: string;
 
-  constructor (
-    topicId: number,
-    walletId: string,
-    name: string,
-    dependencies: Array<StepDependency>,
-    issuer?: Issuer,
-    credData?: any
-    ) {
-      this.topicId = topicId;
-      this.walletId = walletId;
-      this.name = name;
-      this.dependencies = dependencies;
-      this.issuer = issuer;
-      if (credData) {
-        this.credentialId = credData.id;
-        this.effectiveDate = credData.effective_date;
+  constructor ( stepData: any ) {
+      this.topicId = stepData.topicId;
+      this.walletId = stepData.walletId;
+      this.name = stepData.stepName;
+      this.dependencies = stepData.dependencies;
+      this.issuer = stepData.issuer;
+      if (stepData.credData) {
+        this.credentialId = stepData.credData.id;
+        this.effectiveDate = stepData.credData.effective_date;
+      }
+
+      this.requestedSchema = {
+        name: '',
+        version: '',
+        did: ''
+      }
+      if (stepData.schema) {
+        this.requestedSchema.name = stepData.schema.name;
+        this.requestedSchema.version = stepData.schema.version;
+        this.requestedSchema.did = stepData.schema.did;
       }
     }
 }

--- a/dflow-demo/src/app/services/tob.service.ts
+++ b/dflow-demo/src/app/services/tob.service.ts
@@ -23,8 +23,8 @@ export class TobService {
    * Queries ToB and returns a list of @Issuer entities that are currently registered.
    */
   getIssuers () {
-    const reqURL = '/bc-tob/issuer';
-    // const reqURL = '/assets/data/issuers.json';
+    // const reqURL = '/bc-tob/issuer';
+    const reqURL = '/assets/data/issuers.json';
     // TODO: use types if possible
     return this.http.get(reqURL);
   }
@@ -32,8 +32,9 @@ export class TobService {
   /**
    * Queries ToB and returns the list of @Schema objects that are currently registered.
    */
-  getSchemas () {
-    const reqURL = '/bc-tob/schema';
+  getLatestSchemas () {
+    // const reqURL = '/bc-tob/schema?inactive=false&latest=true&revoked=false';
+    const reqURL = '/assets/data/schemas.json';
     // TODO: use types if possible
     return this.http.get(reqURL);
   }
@@ -43,8 +44,8 @@ export class TobService {
    * @param topicId the id of the topic being requested
    */
   getTopicById (topicId: number) {
-    const reqURL = `/bc-tob/topic/${topicId}/formatted`;
-    // const reqURL = '/assets/data/topic.json';
+    // const reqURL = `/bc-tob/topic/${topicId}/formatted`;
+    const reqURL = '/assets/data/topic.json';
     // TODO: use types if possible
     return this.http.get(reqURL);
   }

--- a/dflow-demo/src/app/services/tob.service.ts
+++ b/dflow-demo/src/app/services/tob.service.ts
@@ -17,9 +17,11 @@ export class TobService {
    * @param did The did of the issuer issuing the specified schema.
    */
   getPathToStep (name: string, version: string, did: string) {
-    const reqURL = `get-credential-dependencies?schema_name=${name}&schema_version=${version}&origin_did=${did}`;
+    // TODO: need a way of determining the baseURL for an agent
+    const baseURL = '/bcreg';
+    const reqURL = `${baseURL}/get-credential-dependencies?schema_name=${name}&schema_version=${version}&origin_did=${did}`;
     // const reqURL = '/assets/data/topology.json';
-    return this.http.post(reqURL, {});
+    return this.http.post(reqURL, null);
   }
 
   /**

--- a/dflow-demo/src/app/services/tob.service.ts
+++ b/dflow-demo/src/app/services/tob.service.ts
@@ -12,19 +12,22 @@ export class TobService {
 
   /**
    * Returns the path - described as step and dependencies - to a step.
+   * @param name The name of the shema being looked up.
+   * @param version The version of the schema being looked up.
+   * @param did The did of the issuer issuing the specified schema.
    */
-  getPathToStep () {
-    // TODO: make actual service call, based on input parameter rather than hard-coded data
-    const reqURL = '/assets/data/topology.json';
-    return this.http.get(reqURL);
+  getPathToStep (name: string, version: string, did: string) {
+    const reqURL = `get-credential-dependencies?schema_name=${name}&schema_version=${version}&origin_did=${did}`;
+    // const reqURL = '/assets/data/topology.json';
+    return this.http.post(reqURL, {});
   }
 
   /**
    * Queries ToB and returns a list of @Issuer entities that are currently registered.
    */
   getIssuers () {
-    // const reqURL = '/bc-tob/issuer';
-    const reqURL = '/assets/data/issuers.json';
+    const reqURL = '/bc-tob/issuer';
+    // const reqURL = '/assets/data/issuers.json';
     // TODO: use types if possible
     return this.http.get(reqURL);
   }
@@ -33,8 +36,8 @@ export class TobService {
    * Queries ToB and returns the list of @Schema objects that are currently registered.
    */
   getLatestSchemas () {
-    // const reqURL = '/bc-tob/schema?inactive=false&latest=true&revoked=false';
-    const reqURL = '/assets/data/schemas.json';
+    const reqURL = '/bc-tob/schema?inactive=false&latest=true&revoked=false';
+    // const reqURL = '/assets/data/schemas.json';
     // TODO: use types if possible
     return this.http.get(reqURL);
   }
@@ -44,8 +47,8 @@ export class TobService {
    * @param topicId the id of the topic being requested
    */
   getTopicById (topicId: number) {
-    // const reqURL = `/bc-tob/topic/${topicId}/formatted`;
-    const reqURL = '/assets/data/topic.json';
+    const reqURL = `/bc-tob/topic/${topicId}/formatted`;
+    // const reqURL = '/assets/data/topic.json';
     // TODO: use types if possible
     return this.http.get(reqURL);
   }

--- a/dflow-demo/src/assets/data/credentials-by-topic.json
+++ b/dflow-demo/src/assets/data/credentials-by-topic.json
@@ -30,7 +30,7 @@
               "create_timestamp": "2018-11-14T19:46:03.042995Z",
               "update_timestamp": "2018-11-14T19:46:03.045791Z",
               "name": "registration.permitify",
-              "version": "1.0.4",
+              "version": "1.0.5",
               "origin_did": "6qnvgJtqwK44D8LFYnV5Yf"
           }
       },
@@ -199,7 +199,7 @@
                           "create_timestamp": "2018-11-14T19:46:03.042995Z",
                           "update_timestamp": "2018-11-14T19:46:03.045791Z",
                           "name": "registration.permitify",
-                          "version": "1.0.4",
+                          "version": "1.0.5",
                           "origin_did": "6qnvgJtqwK44D8LFYnV5Yf"
                       }
                   },
@@ -363,7 +363,7 @@
               "create_timestamp": "2018-11-14T19:45:48.365275Z",
               "update_timestamp": "2018-11-14T19:45:48.369882Z",
               "name": "pst_number.permitify",
-              "version": "1.0.4",
+              "version": "1.0.5",
               "origin_did": "CYnWiuEtJJuhpWvVz3kY9D"
           }
       },
@@ -476,7 +476,7 @@
                           "create_timestamp": "2018-11-14T19:45:48.365275Z",
                           "update_timestamp": "2018-11-14T19:45:48.369882Z",
                           "name": "pst_number.permitify",
-                          "version": "1.0.4",
+                          "version": "1.0.5",
                           "origin_did": "CYnWiuEtJJuhpWvVz3kY9D"
                       }
                   },

--- a/dflow-demo/src/assets/data/schemas.json
+++ b/dflow-demo/src/assets/data/schemas.json
@@ -12,7 +12,7 @@
       "create_timestamp": "2018-11-29T10:40:00.084068-08:00",
       "update_timestamp": "2018-11-29T10:40:00.088154-08:00",
       "name": "worksafe.permitify",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "origin_did": "MAcounf9HxhgnqqhzReTLC"
     },
     {
@@ -20,7 +20,7 @@
       "create_timestamp": "2018-11-29T10:40:04.841723-08:00",
       "update_timestamp": "2018-11-29T10:40:04.846530-08:00",
       "name": "pst_number.permitify",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "origin_did": "CYnWiuEtJJuhpWvVz3kY9D"
     },
     {
@@ -28,7 +28,7 @@
       "create_timestamp": "2018-11-29T10:40:06.661196-08:00",
       "update_timestamp": "2018-11-29T10:40:06.665991-08:00",
       "name": "liquor_license.permitify",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "origin_did": "ScrMddP9C426QPrp1KViZB"
     },
     {
@@ -36,7 +36,7 @@
       "create_timestamp": "2018-11-29T10:40:16.437333-08:00",
       "update_timestamp": "2018-11-29T10:40:16.442444-08:00",
       "name": "registration.permitify",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "origin_did": "6qnvgJtqwK44D8LFYnV5Yf"
     },
     {
@@ -44,7 +44,7 @@
       "create_timestamp": "2018-11-29T10:40:16.472480-08:00",
       "update_timestamp": "2018-11-29T10:40:16.476441-08:00",
       "name": "relationship.permitify",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "origin_did": "6qnvgJtqwK44D8LFYnV5Yf"
     },
     {
@@ -52,7 +52,7 @@
       "create_timestamp": "2018-11-29T10:40:20.166460-08:00",
       "update_timestamp": "2018-11-29T10:40:20.172069-08:00",
       "name": "operating_permit.permitify",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "origin_did": "L6SJy7gNRCLUp8dV94hfex"
     },
     {
@@ -60,7 +60,7 @@
       "create_timestamp": "2018-11-29T10:40:34.050700-08:00",
       "update_timestamp": "2018-11-29T10:40:34.053745-08:00",
       "name": "biz_license.permitify",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "origin_did": "A9Rsuu7FNquw8Ne2Smu5Nr"
     }
   ]

--- a/dflow-demo/src/assets/data/schemas.json
+++ b/dflow-demo/src/assets/data/schemas.json
@@ -1,0 +1,67 @@
+{
+  "total": 7,
+  "page_size": 10,
+  "page": 1,
+  "first_index": 1,
+  "last_index": 7,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "id": 1,
+      "create_timestamp": "2018-11-29T10:40:00.084068-08:00",
+      "update_timestamp": "2018-11-29T10:40:00.088154-08:00",
+      "name": "worksafe.permitify",
+      "version": "1.0.4",
+      "origin_did": "MAcounf9HxhgnqqhzReTLC"
+    },
+    {
+      "id": 2,
+      "create_timestamp": "2018-11-29T10:40:04.841723-08:00",
+      "update_timestamp": "2018-11-29T10:40:04.846530-08:00",
+      "name": "pst_number.permitify",
+      "version": "1.0.4",
+      "origin_did": "CYnWiuEtJJuhpWvVz3kY9D"
+    },
+    {
+      "id": 3,
+      "create_timestamp": "2018-11-29T10:40:06.661196-08:00",
+      "update_timestamp": "2018-11-29T10:40:06.665991-08:00",
+      "name": "liquor_license.permitify",
+      "version": "1.0.4",
+      "origin_did": "ScrMddP9C426QPrp1KViZB"
+    },
+    {
+      "id": 4,
+      "create_timestamp": "2018-11-29T10:40:16.437333-08:00",
+      "update_timestamp": "2018-11-29T10:40:16.442444-08:00",
+      "name": "registration.permitify",
+      "version": "1.0.4",
+      "origin_did": "6qnvgJtqwK44D8LFYnV5Yf"
+    },
+    {
+      "id": 5,
+      "create_timestamp": "2018-11-29T10:40:16.472480-08:00",
+      "update_timestamp": "2018-11-29T10:40:16.476441-08:00",
+      "name": "relationship.permitify",
+      "version": "1.0.4",
+      "origin_did": "6qnvgJtqwK44D8LFYnV5Yf"
+    },
+    {
+      "id": 6,
+      "create_timestamp": "2018-11-29T10:40:20.166460-08:00",
+      "update_timestamp": "2018-11-29T10:40:20.172069-08:00",
+      "name": "operating_permit.permitify",
+      "version": "1.0.4",
+      "origin_did": "L6SJy7gNRCLUp8dV94hfex"
+    },
+    {
+      "id": 7,
+      "create_timestamp": "2018-11-29T10:40:34.050700-08:00",
+      "update_timestamp": "2018-11-29T10:40:34.053745-08:00",
+      "name": "biz_license.permitify",
+      "version": "1.0.4",
+      "origin_did": "A9Rsuu7FNquw8Ne2Smu5Nr"
+    }
+  ]
+}


### PR DESCRIPTION
This resolves #141 

The new revision of dFlow supports querying ToB to retrieve all the latest registered versions of schemas, and draws the graph according to the structure returned by the `/get-credential-dependencies` API call.

The app still needs polishing and some enhancements (e.g.: currently it always uses `bcreg` to query for dependencies, but it should query the target agent instead), but it is fully working.

To llow for the different workflow to be implemented, the landing page was modified to display a dropdown containing all the schemas that have been registered by the agents.
![image](https://user-images.githubusercontent.com/2395873/49270463-67a71700-f41e-11e8-8c96-f537f35bd21d.png)

Once the selection is completed, the user will be taken to a page displaying the graph describing the steps required to obtain the credential.
![image](https://user-images.githubusercontent.com/2395873/49270519-a2a94a80-f41e-11e8-87b7-ea4923757b16.png)

The user will be then able to interact with the graph nodes, and complete the steps required to obtain the desired credential.
![image](https://user-images.githubusercontent.com/2395873/49270489-84dbe580-f41e-11e8-97d0-0e40f21db5f7.png)
