### PR TITLE
Tweaks to dFlow home page

### DIFF
--- a/dflow-demo/src/app/components/home/home.component.ts
+++ b/dflow-demo/src/app/components/home/home.component.ts
@@ -45,6 +45,19 @@ export class HomeComponent implements OnInit {
         });
       });
 
+      // TODO: sort array in-place for now. A pipe will be better once dFlow is refactored.
+      this.availableCreds.sort((a, b) => {
+        const displayA = `${a.issuer.name} - ${a.schema.name}`;
+        const displayB = `${b.issuer.name} - ${b.schema.name}`;
+        if ( displayA < displayB ) {
+            return -1
+        }
+        if ( displayA > displayB ) {
+            return 1
+        }
+        return 0;
+      });
+
       console.log(this.availableCreds);
     });
   }

--- a/dflow-demo/src/app/services/tob.service.ts
+++ b/dflow-demo/src/app/services/tob.service.ts
@@ -28,7 +28,7 @@ export class TobService {
    * Queries ToB and returns a list of @Issuer entities that are currently registered.
    */
   getIssuers () {
-    const reqURL = '/bc-tob/issuer';
+    const reqURL = '/bc-tob/issuer?inactive=false&latest=true&revoked=false&page_size=100';
     // const reqURL = '/assets/data/issuers.json';
     // TODO: use types if possible
     return this.http.get(reqURL);
@@ -38,7 +38,7 @@ export class TobService {
    * Queries ToB and returns the list of @Schema objects that are currently registered.
    */
   getLatestSchemas () {
-    const reqURL = '/bc-tob/schema?inactive=false&latest=true&revoked=false';
+    const reqURL = '/bc-tob/schema?inactive=false&latest=true&revoked=false&page_size=100';
     // const reqURL = '/assets/data/schemas.json';
     // TODO: use types if possible
     return this.http.get(reqURL);


### PR DESCRIPTION
Increased number of requested issuers/schemas: it will now list up to 100 schemas to pick from.
Credential list in home page is now sorted alphabetically.