### PR TITLE
Add support for searching legal entity

### DIFF
--- a/config/city-surrey-agent/services.yml
+++ b/config/city-surrey-agent/services.yml
@@ -1,5 +1,5 @@
 issuers:
-  city-surrey:
+  surrey:
     logo_path: ''
     name: City of Surrey
     abbreviation: SUR
@@ -8,7 +8,6 @@ issuers:
     endpoint: ${ENDPOINT_URL}/surrey
 
     connection:
-      id: surrey
       type: TheOrgBook
       api_url: $TOB_API_URL
       sign_target: false

--- a/config/fraser-valley-agent/services.yml
+++ b/config/fraser-valley-agent/services.yml
@@ -8,7 +8,6 @@ issuers:
     endpoint: ${ENDPOINT_URL}/fraser-valley
 
     connection:
-      id: fraser-valley
       type: TheOrgBook
       api_url: $TOB_API_URL
       sign_target: false

--- a/config/liquor-control-agent/services.yml
+++ b/config/liquor-control-agent/services.yml
@@ -1,5 +1,5 @@
 issuers:
-  liquor-control:
+  liquor:
     logo_path: ''
     name: Liquor Control and Licensing Branch
     abbreviation: LCLB
@@ -8,7 +8,6 @@ issuers:
     endpoint: ${ENDPOINT_URL}/liquor
 
     connection:
-      id: liquor
       type: TheOrgBook
       api_url: $TOB_API_URL
       sign_target: false

--- a/config/ministry-finance-agent/services.yml
+++ b/config/ministry-finance-agent/services.yml
@@ -1,5 +1,5 @@
 issuers:
-  ministry-finance:
+  finance:
     logo_path: ''
     name: BC Ministry of Finance
     abbreviation: Ministry of Finance
@@ -8,7 +8,6 @@ issuers:
     endpoint: ${ENDPOINT_URL}/finance
 
     connection:
-      id: finance
       type: TheOrgBook
       api_url: $TOB_API_URL
       sign_target: false

--- a/config/worksafe-agent/services.yml
+++ b/config/worksafe-agent/services.yml
@@ -1,5 +1,5 @@
 issuers:
-  ministry-finance:
+  worksafe:
     logo_path: ''
     name: WorkSafe BC
     abbreviation: WorkSafe BC"
@@ -8,7 +8,6 @@ issuers:
     endpoint: ${ENDPOINT_URL}/worksafe
 
     connection:
-      id: worksafe
       type: TheOrgBook
       api_url: $TOB_API_URL
       sign_target: false

--- a/dflow-demo/src/app/app-routing.module.ts
+++ b/dflow-demo/src/app/app-routing.module.ts
@@ -5,6 +5,7 @@ import { RecipeComponent } from './components/recipe/recipe.component';
 
 const routes: Routes = [
   { path: '', component: HomeComponent},
+  { path: 'home', component: HomeComponent},
   { path: 'demo', component: RecipeComponent}
 ];
 

--- a/dflow-demo/src/app/app.module.ts
+++ b/dflow-demo/src/app/app.module.ts
@@ -10,6 +10,8 @@ import { HomeComponent } from './components/home/home.component';
 import { RecipeComponent } from './components/recipe/recipe.component';
 import { WorkflowStepComponent } from './components/workflow/workflow-step/workflow-step.component';
 import { FormsModule } from '@angular/forms';
+import { SearchInputComponent } from './components/search/search-input/search-input.component';
+import { GeneralDataService } from './services/general-data.service';
 
 
 
@@ -20,7 +22,8 @@ import { FormsModule } from '@angular/forms';
     HeaderComponent,
     HomeComponent,
     RecipeComponent,
-    WorkflowStepComponent
+    WorkflowStepComponent,
+    SearchInputComponent
   ],
   entryComponents: [
     WorkflowStepComponent
@@ -32,7 +35,9 @@ import { FormsModule } from '@angular/forms';
     HttpClientModule,
     NgbModule
   ],
-  providers: [],
+  providers: [
+    GeneralDataService
+  ],
   bootstrap: [AppComponent]
 })
 export class AppModule { }

--- a/dflow-demo/src/app/components/header/header.component.html
+++ b/dflow-demo/src/app/components/header/header.component.html
@@ -11,7 +11,7 @@
           alt="BC Government Logo">
       </a>
       <div>
-        <a class="navbar-brand" [routerLink]="['/home']" routerLinkActive="active" >dFlow Demo</a>
+        <a class="navbar-brand" [routerLink]="['/home']">dFlow Demo</a>
       </div>
     </div>
   </nav>

--- a/dflow-demo/src/app/components/header/header.component.html
+++ b/dflow-demo/src/app/components/header/header.component.html
@@ -10,8 +10,8 @@
         <img class="img-fluid d-md-none" src="assets/bootstrap/bcid-symbol-rev.svg" width="63" height="44"
           alt="BC Government Logo">
       </a>
-      <div class="navbar-brand">
-        <span translate>dFlow Demo</span>
+      <div>
+        <a class="navbar-brand" [routerLink]="['/home']" routerLinkActive="active" >dFlow Demo</a>
       </div>
     </div>
   </nav>

--- a/dflow-demo/src/app/components/home/home.component.html
+++ b/dflow-demo/src/app/components/home/home.component.html
@@ -21,11 +21,10 @@
   </ng-container>
 
   <ng-container>
-    <div class="form-group">
-      <label class="col-form-label control-label" for="inputDefault">ToB ID (optional):</label>
-      <input type="text" class="form-control col-md-6" id="inputDefault" [(ngModel)]="selectedTopic">
-    </div>
+      <label class="col-form-label control-label">Legal Entity (optional):</label>
+      <search-input #searchInput (accepted)="performSearch($event)"></search-input>
   </ng-container>
 
-  <button class="btn btn-primary" type="button" (click)="begin()">Begin</button>
+
+  <button class="btn btn-primary mt-3" type="button" (click)="begin()">Begin</button>
 </main>

--- a/dflow-demo/src/app/components/home/home.component.ts
+++ b/dflow-demo/src/app/components/home/home.component.ts
@@ -1,12 +1,12 @@
-import { Component, OnInit } from '@angular/core';
-
-import { forkJoin } from 'rxjs';
-import { map } from 'rxjs/operators';
-
-import { TobService } from '../../services/tob.service';
-import { Schema } from '../../models/schema';
-import { Issuer } from 'src/app/models/issuer';
+import { Component, OnInit, ViewChild } from '@angular/core';
 import { Router } from '@angular/router';
+import { forkJoin } from 'rxjs';
+import { Issuer } from 'src/app/models/issuer';
+import { Schema } from '../../models/schema';
+import { TobService } from '../../services/tob.service';
+import { SearchInputComponent } from '../search/search-input/search-input.component';
+
+
 
 @Component({
   selector: 'app-home',
@@ -15,6 +15,8 @@ import { Router } from '@angular/router';
 })
 export class HomeComponent implements OnInit {
 
+  @ViewChild('searchInput') _searchInput: SearchInputComponent;
+
   availableCreds: Array<any>;
   selectedCred: any;
   selectedTopic: string;
@@ -22,7 +24,7 @@ export class HomeComponent implements OnInit {
 
   constructor(
     private tobService: TobService,
-    private router: Router ) {
+    private _router: Router ) {
     this.availableCreds = new Array<any>();
    }
 
@@ -63,6 +65,17 @@ export class HomeComponent implements OnInit {
     });
   }
 
+  /**
+   * Updated the currently selected topic id, if the search was successful
+   * @param evt the event triggered by the typeahead search action
+   */
+  performSearch(evt?) {
+    const selected = this._searchInput.value;
+    if (selected && selected.id) {
+      this.selectedTopic = selected.id;
+    }
+  }
+
   begin() {
     if (!this.selectedCred) {
       // don't proceed if a credential is not selected
@@ -78,7 +91,7 @@ export class HomeComponent implements OnInit {
 
       const url = `/demo?${topicParam}name=${this.selectedCred.schema.name}&version=${this.selectedCred.schema.version}&did=${this.selectedCred.schema.origin_did}`;
 
-      this.router.navigateByUrl(url);
+      this._router.navigateByUrl(url);
     }
   }
 }

--- a/dflow-demo/src/app/components/search/search-input/search-input.component.html
+++ b/dflow-demo/src/app/components/search/search-input/search-input.component.html
@@ -1,0 +1,17 @@
+<div>
+  <ng-template #rt let-r="result" let-t="term">
+    <ngb-highlight [result]="r.term" [term]="t"></ngb-highlight>
+  </ng-template>
+
+  <input [ngClass]="{'form-control': true, 'col-md-6': 'true'}"
+    #queryInput type="text" id="queryInput" name="query" size="40"
+    autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"
+    [ngbTypeahead]="typeaheadSearch" [focusFirst]="false"
+    (selectItem)="typeaheadSelected($event)"
+    [resultTemplate]="rt"
+    [inputFormatter]="formatter">
+  <!-- <button #queryButton class="btn btn-primary">
+    <span class="load" *ngIf="loading"><div class="loading-indicator"></div></span>
+    <span class="fa fa-search" *ngIf="! loading"></span>
+  </button> -->
+</div>

--- a/dflow-demo/src/app/components/search/search-input/search-input.component.scss
+++ b/dflow-demo/src/app/components/search/search-input/search-input.component.scss
@@ -1,0 +1,70 @@
+@import "../../../../../node_modules/@bcgov/bootstrap-theme/dist/scss/common";
+
+$input-border-color: lighten(rgba(theme-color(primary), 0.8), 10%);
+$input-border-active: #5c8de6;
+$input-border-radius: 10px;
+$input-background: theme-color(light);
+
+.large-search {
+  align-items: center;
+  background: $input-background;
+  border: 2px solid $input-border-color;
+  border-bottom-color: rgba($input-border-color, 0.7);
+  border-radius: $input-border-radius;
+  box-shadow: inset 0 1px 2px 2px rgba(0, 10, 30, 0.05);
+  display: flex;
+  flex-flow: row nowrap;
+  max-width: 100%;
+  overflow: hidden;
+  .fa {
+    //color: darken($input-border-color, 10%);
+    color: #fff;
+  }
+  .fa, .load {
+    flex: 0 0 46px;
+    font-size: 26px;
+    height: 28px;
+    line-height: normal;
+    text-align: center;
+    width: 42px;
+  }
+  .loading-indicator {
+    border-top-color: rgba(#fff, 0.8);
+    &::after {
+      border-color: rgba(#fff, 0.2);
+    }
+  }
+  input {
+    background: transparent;
+    border: none;
+    display: block;
+    flex: 1 1 auto;
+    font-size: 22px;
+    line-height: normal;
+    margin: 0;
+    outline: none;
+    padding: 3px 0 3px 10px;
+    width: 100%;
+  }
+  button {
+    border-radius: ($input-border-radius - 4);
+    display: flex;
+    flex: none;
+    margin: 2px;
+  }
+  :host.dark-bg & {
+    border-color: $input-border-color;
+  }
+  &.active {
+    // border-color: $input-border-active;
+    box-shadow: 0 0 0 $btn-focus-width rgba(theme-color(primary), .3);
+    .fa {
+      //color: #7290e9;
+      color: theme-color(light);
+    }
+    :host.dark-bg & {
+      border-color: $input-border-color;
+      box-shadow: 0 0 0 $btn-focus-width rgba(theme-color(light), .4);
+    }
+  }
+}

--- a/dflow-demo/src/app/components/search/search-input/search-input.component.spec.ts
+++ b/dflow-demo/src/app/components/search/search-input/search-input.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SearchInputComponent } from './search-input.component';
+
+describe('SearchInputComponent', () => {
+  let component: SearchInputComponent;
+  let fixture: ComponentFixture<SearchInputComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ SearchInputComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SearchInputComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/dflow-demo/src/app/components/search/search-input/search-input.component.ts
+++ b/dflow-demo/src/app/components/search/search-input/search-input.component.ts
@@ -1,0 +1,135 @@
+import { AfterViewInit, Component, ElementRef, EventEmitter, Input, Output, Renderer2, ViewChild } from '@angular/core';
+import { Observable } from 'rxjs';
+import { debounceTime, distinctUntilChanged, map, switchMap } from 'rxjs/operators';
+import { GeneralDataService } from 'src/app/services/general-data.service';
+
+@Component({
+  selector: 'search-input',
+  templateUrl: './search-input.component.html',
+  styleUrls: ['./search-input.component.scss']
+})
+
+
+export class SearchInputComponent implements AfterViewInit {
+
+  @ViewChild('queryInput') private _input : ElementRef;
+  @Output() accepted = new EventEmitter<any>();
+  @Output() queryChange = new EventEmitter<any>();
+  @Output() focusChange = new EventEmitter<boolean>();
+
+  protected _delay: number = 150;
+  protected _focused: boolean = false;
+  protected _inputTimer;
+  protected _lastQuery: any;
+  protected _loading: boolean = false;
+  protected _query: any = {};
+
+  constructor(
+    private _renderer: Renderer2,
+    private _dataService: GeneralDataService,
+  ) {}
+
+  get value(): any {
+    return this._query;
+  }
+
+  set value(val: any) {
+    this._query = val;
+    if(this._input) this._input.nativeElement.value = val.term;
+  }
+
+  get focused() {
+    return this._focused;
+  }
+
+  focus() {
+    requestAnimationFrame(() => {
+      if(this._input) this._input.nativeElement.select();
+    });
+  }
+
+  get loading() {
+    return this._loading;
+  }
+
+  @Input() set loading(val: boolean) {
+    this._loading = val;
+  }
+
+  ngAfterViewInit() {
+    if(! this._input) {
+      console.error('search input element not found');
+      return;
+    }
+    let input_elt = this._input.nativeElement;
+    this._renderer.listen(input_elt, 'focus', (event) => {
+      this._focused = true;
+      this.focusChange.emit(this._focused);
+    });
+    this._renderer.listen(input_elt, 'blur', (event) => {
+      this._focused = false;
+      this.focusChange.emit(this._focused);
+    });
+    this._renderer.listen(input_elt, 'input', (event) => {
+      this.updateQuery(event.target.value, true);
+    });
+    this._renderer.listen(input_elt, 'change', (event) => {
+      this.updateQuery(event.target.value);
+    });
+    this._renderer.listen(input_elt, 'keydown', (event) => {
+      if(event.keyCode === 13) {
+        event.preventDefault();
+        this.acceptInput();
+      }
+    });
+  }
+
+  protected acceptInput() {
+    this.accepted.emit(null);
+  }
+
+  protected updateQuery(value: any, live?: boolean) {
+    let old = this._lastQuery;
+    if(value === undefined || value === null) {
+      value = {};
+    }
+    this._query = value;
+    if(old !== value) {
+      clearTimeout(this._inputTimer);
+      if(live) {
+        this._inputTimer = setTimeout(this.updated.bind(this), this._delay);
+      } else {
+        this.updated();
+      }
+    }
+  }
+
+  protected updated() {
+    if(this._lastQuery !== this._query) {
+      this._lastQuery = this._query;
+      this.queryChange.emit(this._lastQuery);
+    }
+  }
+
+  get typeaheadSearch() {
+    return (text$: Observable<string>) => {
+      return text$.pipe(
+        debounceTime(200),
+        distinctUntilChanged(),
+        switchMap(term => this._dataService.autocomplete(term))
+      );
+    }
+  }
+
+  typeaheadSelected(evt) {
+    evt.preventDefault();
+    let val = evt.item;
+    this.value = val;
+    this.updateQuery(val);
+    this.acceptInput();
+  }
+
+  formatter (x: any) {
+    return x.term;
+  }
+}

--- a/dflow-demo/src/app/data-types.ts
+++ b/dflow-demo/src/app/data-types.ts
@@ -1,0 +1,934 @@
+import { BehaviorSubject, Observable, Subscription } from 'rxjs';
+import { map, filter } from 'rxjs/operators';
+
+function load_data<T>(
+    obj: T,
+    result: any,
+    attr_map?: {[key: string]: any},
+    list_map?: {[key: string]: any}): T {
+  if(obj && result) {
+    for(let k in result) {
+      if(attr_map && k in attr_map) {
+        obj[k] = (result[k] === null || result[k] === undefined)
+          ? null : (new Model[attr_map[k]])._load(result[k]);
+      }
+      else if(list_map && k in list_map) {
+        obj[k] = (result[k] === null || result[k] === undefined)
+          ? [] : result[k].map((v) => (new Model[list_map[k]])._load(v));
+      }
+      else {
+        obj[k] = result[k];
+      }
+    }
+  }
+  return obj;
+}
+
+
+export namespace Model {
+
+  export interface ModelCtor<M extends BaseModel> {
+    new (value?: any): M;
+    propertyMap: {[key: string]: string};
+    listPropertyMap: {[key: string]: string};
+    resourceName: string;
+    childResource: string;
+    extPath: string;
+  }
+
+  export abstract class BaseModel {
+    static propertyMap: {[key: string]: string} = {};
+    static listPropertyMap: {[key: string]: string} = {};
+    static resourceName: string;
+    static childResource: string;
+    static extPath: string;
+
+    constructor(data?: any) {
+      if(data) {
+        this._load(data);
+      }
+    }
+
+    _load<T extends BaseModel>(result: any) {
+      let ctor = (this.constructor as ModelCtor<T>);
+      return load_data(this, result, ctor.propertyMap, ctor.listPropertyMap);
+    }
+
+    get pageTitle(): string {
+      return null;
+    }
+  }
+
+  function mapByType<T extends {type: string}>(input: T[]): {[key: string]: T} {
+    let result = {};
+    if(input) {
+      for(let obj of input) {
+        result[obj.type] = obj;
+      }
+    }
+    return result;
+  }
+
+  export class Address extends BaseModel {
+    id: number;
+    addressee: string;
+    civic_address: string;
+    city: string;
+    province: string;
+    postal_code: string;
+    country: string;
+    address_type: string;
+    credential_id: number;
+    inactive: boolean;
+
+    static resourceName = 'address';
+  }
+
+  export class Attribute extends BaseModel {
+    id: number;
+    type: string;
+    format: string;
+    value: string;
+    credential_id: number;
+    inactive: boolean;
+
+    get typeClass(): string {
+      if(this.format === 'email' || this.format === 'phone' || this.format === 'name')
+        return this.format;
+      if(this.format === 'url')
+        return 'website';
+    }
+
+    get typeLabel(): string {
+      if(this.type && ! ~this.type.indexOf('.'))
+        return `attribute.${this.type}`;
+      return this.type;
+    }
+  }
+
+  export class Credential extends BaseModel {
+    id: number;
+    credential_type: CredentialType;
+    credential_set: CredentialSet;
+    effective_date: string;
+    inactive: boolean;
+    latest: boolean;
+    revoked: boolean;
+    revoked_date: string;
+    last_issue_date: string;
+
+    addresses: Address[];
+    _attributes: Attribute[];
+    _attribute_map: {[key: string]: Attribute};
+    names: Name[];
+    topic: Topic;
+    related_topics: Topic[];
+
+    get pageTitle(): string {
+      return this.credential_type && this.credential_type.description;
+    }
+
+    static resourceName = 'credential';
+
+    static propertyMap = {
+      credential_type: 'CredentialType',
+      credential_set: 'CredentialSet',
+      topic: 'Topic',
+    };
+    static listPropertyMap = {
+      addresses: 'Address',
+      attributes: 'Attribute',
+      names: 'Name',
+      related_topics: 'Topic',
+    };
+
+    get attributes(): Attribute[] {
+      return this._attributes;
+    }
+    set attributes(attrs: Attribute[]) {
+      this._attributes = attrs;
+      this._attribute_map = mapByType(this._attributes);
+    }
+
+    get attribute_map(): {[key: string]: Attribute} {
+      return this._attribute_map || {};
+    }
+
+    get issuer(): Issuer {
+      return this.credential_type && this.credential_type.issuer;
+    }
+    set issuer(val: Issuer) {
+    }
+    get haveAddresses() {
+      return this.topic.addresses && this.topic.addresses.length;
+    }
+    get haveAttributes() {
+      return this.attributes && this.attributes.length;
+    }
+    get haveNames() {
+      return this.names && this.names.length;
+    }
+
+    get link() {
+      if(this.topic) {
+        return this.topic.link.concat(['/cred/', ''+this.id]);
+      }
+    }
+  }
+
+  export class CredentialFormatted extends Credential {
+    static extPath = 'formatted';
+  }
+
+  export class CredentialSearchResult extends Credential {
+    static resourceName = 'search/credential/topic';
+  }
+
+  export class CredentialFacetSearchResult extends Credential {
+    static resourceName = 'search/credential/topic/facets';
+  }
+
+  export class CredentialVerifyResult extends BaseModel {
+    success: boolean;
+    result: any;
+
+    static resourceName = 'credential';
+    static extPath = 'verify';
+
+    get claims() {
+      let ret = [];
+      if(typeof this.result === 'object' && this.result.proof) {
+        let attrs = this.result.proof.requested_proof.revealed_attrs;
+        for(let k in attrs) {
+          ret.push({name: k, value: attrs[k].raw});
+        }
+      }
+      ret.sort((a,b) => a.name.localeCompare(b.name));
+      return ret;
+    }
+
+    get status(): string {
+      return this.success ? 'cred.verified' : 'cred.not-verified';
+    }
+
+    get text(): string {
+      if(typeof this.result === 'string')
+        return this.result;
+      return JSON.stringify(this.result, null, 2);
+    }
+  }
+
+  export class CredentialSet extends BaseModel {
+    id: number;
+    credentials: Credential[];
+    credential_type: CredentialType;
+    latest_credential: Credential;
+    latest_credential_id: number;
+    first_effective_date: string;
+    last_effective_date: string;
+
+    static propertyMap = {
+      latest_credential: 'Credential',
+      credential_type: 'CredentialType',
+      topic: 'Topic',
+    };
+    static listPropertyMap = {
+      credentials: 'Credential',
+    };
+
+    static resourceName = 'topic';
+    static childResource = 'credentialset';
+  }
+
+  export class CredentialType extends BaseModel {
+    id: number;
+    // schema: Schema;
+    issuer: Issuer;
+    description: string;
+    // processorConfig: string;
+    credential_def_id: string;
+    // visible_fields: string;
+    has_logo: boolean;
+
+    static resourceName = 'credentialtype';
+
+    static propertyMap = {
+      issuer: 'Issuer',
+    };
+
+    get logo_url(): string {
+      if(this.has_logo) {
+        return `${CredentialType.resourceName}/${this.id}/logo`;
+      }
+    }
+  }
+
+  export class Issuer extends BaseModel {
+    id: number;
+    did: string;
+    name: string;
+    abbreviation: string;
+    email: string;
+    url: string;
+    has_logo: boolean;
+
+    static resourceName = 'issuer';
+
+    get pageTitle(): string {
+      return this.name;
+    }
+
+    get logo_url(): string {
+      if(this.has_logo) {
+        return `${Issuer.resourceName}/${this.id}/logo`;
+      }
+    }
+  }
+
+  export class IssuerCredentialType extends CredentialType {
+    static resourceName = 'issuer';
+    static childResource = 'credentialtype';
+  }
+
+  export class Name extends BaseModel {
+    id: number;
+    text: string;
+    type: string;
+    credential_id: number;
+    inactive: boolean;
+
+    static resourceName = 'name';
+
+    // extra API fields
+    issuer: Issuer;
+    static propertyMap = {
+      issuer: 'Issuer',
+    };
+  }
+
+  export class Topic extends BaseModel {
+    id: number;
+    source_id: string;
+    type: string;
+
+    addresses: Address[];
+    _attributes: Attribute[];
+    _attribute_map: {[key: string]: Attribute};
+    names: Name[];
+
+    static resourceName = 'topic';
+
+    static listPropertyMap = {
+      addresses: 'Address',
+      attributes: 'Attribute',
+      names: 'Name',
+    };
+
+    get attributes(): Attribute[] {
+      return this._attributes;
+    }
+    set attributes(attrs: Attribute[]) {
+      this._attributes = attrs;
+      this._attribute_map = mapByType(this._attributes);
+    }
+
+    get attribute_map(): {[key: string]: Attribute} {
+      return this._attribute_map || {};
+    }
+
+    get pageTitle(): string {
+      if(this.names && this.names.length) {
+        return this.names[0].text;
+      }
+    }
+
+    get preferredName(): Name {
+      let found = null;
+      if(this.names) {
+        for(let name of this.names) {
+          if(name.type === 'entity_name')
+            found = name;
+        }
+        if(! found)
+          found = this.names[0];
+      }
+      return found;
+    }
+
+    get typeLabel(): string {
+      if(this.type) return ('name.'+this.type).replace(/_/g, '-');
+      return '';
+    }
+
+    get link(): string[] {
+      // FIXME need to move link generation into general data service
+      if(this.type === 'registration')
+        return ['/topic/', this.source_id];
+      return ['/topic/', this.type, this.source_id];
+    }
+
+    extLink(...args): string[] {
+      return this.link.concat(args)
+    }
+  }
+
+  export class TopicFormatted extends Topic {
+    static extPath = 'formatted';
+  }
+
+  export class TopicRelatedFrom extends Topic {
+    static childResource = 'related_from';
+  }
+
+  export class TopicRelatedTo extends Topic {
+    static childResource = 'related_to';
+  }
+
+}
+// end Model
+
+
+export namespace Fetch {
+
+  export class BaseResult<T> {
+    public data: T;
+    public meta: any;
+    protected _input: any;
+
+    constructor(
+        protected _ctor: (any) => T,
+        input?: any,
+        public error?: any,
+        public loading: boolean = false,
+        meta = null) {
+      this.input = input;
+      this.meta = meta || {};
+    }
+
+    get input(): any {
+      return this._input;
+    }
+
+    set input(value: any) {
+      this._input = value;
+      this.data = value ? this._ctor(value) : null;
+    }
+
+    get empty(): boolean {
+      return ! this.data;
+    }
+
+    get loaded(): boolean {
+      return !! this.data;
+    }
+
+    get notFound(): boolean {
+      return this.error && this.error.obj && this.error.obj.status === 404;
+    }
+  }
+
+  export class ListInfo {
+    public pageNum: number = 1;
+    public pageCount: number = 0;
+    public resultCount: number = 0;
+    public totalCount: number = 0;
+    public firstIndex = 0;
+    public lastIndex = 0;
+    public timing: number = 0;
+    public previous: string = null;
+    public next: string = null;
+    public params: {[key: string]: any};
+    public facets: any;
+
+    get havePrevious(): boolean {
+      return this.previous != null;
+    }
+
+    get haveNext(): boolean {
+      return this.next != null;
+    }
+
+    static fromResult(value: any, facets?: any): ListInfo {
+      let ret = new ListInfo();
+      ret.facets = facets;
+      if(value) {
+        ret.pageNum = value.page || null;
+        ret.firstIndex = value.first_index || null;
+        ret.lastIndex = value.last_index || null;
+        ret.totalCount = value.total || null;
+        ret.next = value.next || null;
+        ret.previous = value.previous || null;
+      }
+      return ret;
+    }
+  }
+
+  export class ListResult<T> extends BaseResult<T[]> {
+    public info: ListInfo;
+
+    get input(): any {
+      return this._input;
+    }
+
+    set input(value: any) {
+      this._input = value;
+      if(value instanceof Array) {
+        this.data = this._ctor(value);
+      }
+      else if(value && 'results' in value && value['results'] instanceof Array) {
+        this.data = this._ctor(value['results']);
+        this.info = ListInfo.fromResult(value);
+      }
+      else if(value && 'objects' in value) {
+        this.data = this._ctor(value['objects']['results']);
+        this.info = ListInfo.fromResult(value['objects'], value['facets']);
+      }
+      else {
+        this.data = null;
+      }
+    }
+  }
+
+  export interface ResultCtor<T, R extends BaseResult<T>> {
+    new (
+      ctor: (any) => T,
+      input?: any,
+      error?: any,
+      loading?: boolean,
+      meta?: any): R;
+  }
+
+  export class RequestParams {
+    path?: string;
+    resource?: string;
+    recordId?: string;
+    childResource?: string;
+    childId?: string;
+    extPath?: string;
+    persist: boolean = false;
+
+    static fromModel<M extends Model.BaseModel>(ctor: Model.ModelCtor<M>) {
+      let req = new RequestParams();
+      req.resource = ctor.resourceName;
+      req.childResource = ctor.childResource;
+      req.extPath = ctor.extPath;
+      return req;
+    }
+
+    static from(params: any) {
+      let req = new RequestParams();
+      if(params)
+        Object.assign(req, params);
+      return req;
+    }
+
+    extend(info: RequestParams | { [key: string]: any }) {
+      let ret = new RequestParams();
+      Object.assign(ret, this);
+      if(info)
+        Object.assign(ret, info);
+      return ret;
+    }
+
+    getRecordPath(recordId?: string, childId?: string, extPath?: string): string {
+      let path = null;
+      if(this.path) {
+        path = this.path;
+      }
+      else if(this.resource) {
+        if(! recordId) recordId = this.recordId;
+        if(! extPath) extPath = this.extPath;
+        if(recordId) {
+          path = `${this.resource}/${recordId}`;
+          if(this.childResource) {
+            if(! childId) childId = this.childId;
+            if(childId)
+              path = `${path}/${this.childResource}/${childId}`;
+            else
+              path = null;
+          }
+          else if(extPath) {
+            path = `${path}/${extPath}`;
+          }
+        }
+      }
+      return path;
+    }
+
+    getListPath(recordId?: string, extPath?: string): string {
+      let path = null;
+      if(this.path) {
+        path = this.path;
+      }
+      else if(this.resource) {
+        if(! recordId) recordId = this.recordId;
+        if(! extPath) extPath = this.extPath;
+        path = this.resource;
+        if(this.childResource) {
+          if(recordId)
+            path = `${path}/${recordId}/${this.childResource}`;
+          else
+            path = null;
+        }
+        else if(extPath) {
+          path = `${path}/${extPath}`;
+        }
+      }
+      return path;
+    }
+  }
+
+  export class BaseLoader<T, R extends BaseResult<T>> {
+    _result: BehaviorSubject<R>;
+    _sub: Subscription;
+
+    constructor(
+      protected _rctor: ResultCtor<T, R>,
+      protected _map: (any) => T,
+      protected _req?: RequestParams
+    ) {
+      if(! this._req) this._req = new RequestParams();
+      this._result = new BehaviorSubject(this._makeResult());
+    }
+
+    complete() {
+      this._clearSub();
+      if(this._result) {
+        this._result.complete();
+        this._result = null;
+      }
+    }
+
+    reset() {
+      this._clearSub();
+      this.result = this._makeResult();
+    }
+
+    _clearSub() {
+      if(this._sub) {
+        this._sub.unsubscribe();
+        this._sub = null;
+      }
+    }
+
+    protected _makeResult(input?: any, error?: any, loading: boolean = false, meta=null) {
+      return new this._rctor(this._map, input, error, loading, meta);
+    }
+
+    get stream(): Observable<R> {
+      return this._result.asObservable();
+    }
+
+    // get ready(): Observable<R> {
+    //   return this.stream.filter(result => result.loaded);
+    // }
+
+    get result(): R {
+      return this._result.value;
+    }
+
+    set result(val: R) {
+      this._result.next(val);
+    }
+
+    get request(): RequestParams {
+      return this._req;
+    }
+
+    loadData(input: any, meta = null) {
+      this.result = this._makeResult(input, null, false, meta);
+    }
+
+    loadError(err: any, meta = null) {
+      this.result = this._makeResult(null, err, false, meta);
+    }
+
+    loadFrom(obs: Observable<any>, meta = null) {
+      this._clearSub();
+      let input = this._req.persist ? this.result.input : null;
+      this.result = this._makeResult(input, null, true, meta);
+      this._sub = obs.subscribe(
+        (result) => this.loadData(result, meta),
+        (err) => this.loadError(err, meta)
+      );
+    }
+
+    loadNotFound(meta = null) {
+      this.loadError({obj: {status: 404}});
+    }
+  }
+
+  export class DataLoader<T> extends BaseLoader<T, BaseResult<T>> {
+    constructor(
+        map: (any) => T,
+        req?: RequestParams) {
+      super(BaseResult, map, req);
+    }
+  }
+
+  export class JsonLoader extends DataLoader<any> {
+    constructor(req?: RequestParams) {
+      super(val => val, req);
+    }
+  }
+
+  export class ListLoader<T> extends BaseLoader<T[], ListResult<T>> {
+    constructor(
+        protected _mapEntry: (any) => T,
+        req?: RequestParams) {
+      super(
+        ListResult,
+        data => {
+          let list = null;
+          if(data instanceof Array) {
+            list = [];
+            for(let row of data) {
+              list.push(_mapEntry(row));
+            }
+          } else if(data) {
+            console.error("Expected array");
+          }
+          return list;
+        },
+        req);
+    }
+  }
+
+  export class ModelLoader<M extends Model.BaseModel> extends DataLoader<M> {
+    constructor(ctor: Model.ModelCtor<M>, req?: RequestParams | { [key: string]: any }) {
+      let creq = RequestParams.fromModel(ctor).extend(req);
+      super((data) => new ctor(data), creq);
+    }
+  }
+
+  export class ModelListLoader<M extends Model.BaseModel> extends ListLoader<M> {
+    constructor(ctor: Model.ModelCtor<M>, req?: RequestParams | { [key: string]: any }) {
+      let creq = RequestParams.fromModel(ctor).extend(req);
+      super((data) => new ctor(data), creq);
+    }
+  }
+}
+// end Fetch
+
+
+export namespace Filter {
+
+  export interface Option {
+    label?: string;
+    tlabel?: string;
+    value: string;
+    active?: boolean;
+    count?: number;
+  }
+
+  export interface FieldSpec {
+    name: string;
+    label?: string;
+    alias?: string;
+    options?: Option[];
+    hidden?: boolean;
+    defval?: string;
+    value?: string;
+    blank?: boolean;
+  }
+
+  export class Field implements FieldSpec {
+    public id = '';
+    public name = '';
+    public alias = null;
+    public label = '';
+    public hidden = false;
+    public defval = '';
+    public blank = false;
+    _options: any[];
+    _value: string = null;
+
+    constructor(init?: FieldSpec) {
+      if(init) {
+        Object.assign(this, init);
+        this.options = init.options;
+      }
+    }
+
+    clone() {
+      return new Field(this);
+    }
+
+    get options() {
+      return this._options;
+    }
+
+    set options(vals) {
+      this._options = vals ? vals.map(o => Object.assign({}, o)) : [];
+      for(let o of this._options) {
+        if(! o.id) o.id = this.name + '_' + (o.value || 'blank');
+      }
+      this.setActive();
+    }
+
+    get value() {
+      return this._value;
+    }
+
+    set value(val: string) {
+      if(val === undefined || val === null) val = this.defval;
+      this._value = val;
+      this.setActive();
+    }
+
+    setActive() {
+      let val = this.value;
+      if(this._options) {
+        for(let o of this._options) {
+          o.active = (o.value === val);
+        }
+      }
+    }
+  }
+
+  interface StrDict {[key: string]: string}
+
+  export class FieldSet {
+    _result: BehaviorSubject<Field[]>;
+    _fields: Field[] = [];
+    _defaults: StrDict = {};
+    _values: StrDict = {};
+
+    constructor(
+      fields: FieldSpec[]
+    ) {
+      let fs = [];
+      if(fields) {
+        for(let opt of fields)
+          fs.push(new Field(opt));
+      }
+      this._fields = fs;
+      this._result = new BehaviorSubject(this._next());
+    }
+
+    loadQuery(params: StrDict) {
+      let upd = {};
+      for(let opt of this._fields) {
+        let k = opt.alias || opt.name;
+        if(k in params)
+          upd[opt.name] = params[k];
+      }
+      this.update(upd);
+    }
+
+    get stream(): Observable<Field[]> {
+      return this._result.asObservable();
+    }
+
+    // get streamVisible(): Observable<Field[]> {
+    //   return this.stream.map(fs => fs.filter(f => ! f.hidden));
+    // }
+
+    get result(): Field[] {
+      return this._result.value;
+    }
+
+    get queryParams(): StrDict {
+      let fs = this.result;
+      let ret = {};
+      for(let opt of fs) {
+        if(opt.value !== null) {
+          ret[opt.alias || opt.name] = opt.value;
+        }
+      }
+      return ret;
+    }
+
+    complete() {
+      if(this._result) {
+        this._result.complete();
+        this._result = null;
+      }
+    }
+
+    reset() {
+      this.values = {};
+    }
+
+    getFieldValue(key: string): string {
+      return this._values[key];
+    }
+
+    setFieldValue(key: string, value: string|number) {
+      let upd = {};
+      upd[key] = value;
+      this.update(upd);
+    }
+
+    setOptions(key: string, value: any) {
+      for(let f of this._fields) {
+        if(f.name === key) {
+          f.options = value;
+          this.update();
+          break;
+        }
+      }
+    }
+
+    update(vals?: StrDict) {
+      let v = {... this._values};
+      if(vals)
+        Object.assign(v, vals);
+      this.values = v;
+    }
+
+    _next() {
+      let vs = this._values;
+      let fs = [];
+      for(let f of this._fields) {
+        let f2 = f.clone();
+        f2.value = vs[f2.name];
+        fs.push(f2);
+      }
+      return fs;
+    }
+
+    _update() {
+      if(this._result)
+        this._result.next(this._next());
+    }
+
+    get defaults() {
+      return this._defaults;
+    }
+
+    set defaults(vals: StrDict) {
+      this._defaults = vals || {};
+      this.update();
+    }
+
+    get values() {
+      return {... this._values};
+    }
+
+    set values(vals: StrDict) {
+      let v = {};
+      for(let f of this._fields) {
+        let defval = f.defval;
+        if(f.name in this._defaults)
+          defval = this._defaults[f.name];
+        if(vals && f.name in vals && vals[f.name] !== null) {
+          let input = vals[f.name];
+          if(typeof input === 'string' || typeof input === 'number') {
+            input = ('' + input).trim();
+          }
+          if(input === '' && defval !== '' && ! f.blank) {
+            input = defval;
+          }
+          v[f.name] = input;
+        }
+        else {
+          v[f.name] = defval;
+        }
+      }
+      this._values = v;
+      this._update();
+    }
+  }
+}
+// end Filter

--- a/dflow-demo/src/app/services/general-data.service.spec.ts
+++ b/dflow-demo/src/app/services/general-data.service.spec.ts
@@ -1,0 +1,12 @@
+import { TestBed } from '@angular/core/testing';
+
+import { GeneralDataService } from './general-data.service';
+
+describe('GeneralDataService', () => {
+  beforeEach(() => TestBed.configureTestingModule({}));
+
+  it('should be created', () => {
+    const service: GeneralDataService = TestBed.get(GeneralDataService);
+    expect(service).toBeTruthy();
+  });
+});

--- a/dflow-demo/src/app/services/general-data.service.ts
+++ b/dflow-demo/src/app/services/general-data.service.ts
@@ -129,14 +129,20 @@ export class GeneralDataService {
           let found = null;
           for(let name of row.names) {
             if(~ name.text.toLowerCase().indexOf(term.toLowerCase())) {
-              found = name.text;
+              found = {
+                id: name.id,
+                term: name.text
+              };
               break;
             } else if(found === null) {
-              found = name.text;
+              found = {
+                id: name.id,
+                term: name.text
+              };
             }
           }
           if(found !== null) {
-            ret.push({id: row.id, term: found});
+            ret.push(found);
           }
         }
         return ret;

--- a/dflow-demo/src/app/services/general-data.service.ts
+++ b/dflow-demo/src/app/services/general-data.service.ts
@@ -1,0 +1,242 @@
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable, Subscription, of, throwError as _throw } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
+import { Fetch, Model } from 'src/app/data-types';
+import { environment } from 'src/environments/environment';
+
+
+@Injectable()
+export class GeneralDataService {
+
+  public apiUrl = environment.API_URL;
+  private _quickLoaded = false;
+  private _orgData : {[key: string]: any} = {};
+  private _recordCounts : {[key: string]: number} = {};
+  private _currentResultSubj = new BehaviorSubject<Fetch.BaseResult<any>>(null);
+  private _loaderSub: Subscription = null;
+  private _defaultTopicType = 'registration';
+
+  constructor(
+    private _http: HttpClient
+  ) {
+  }
+
+  getRequestUrl(path: string) : string {
+    if(typeof path === 'string' && path.match(/^(\/\/|\w+:\/\/)\w/)) {
+      // absolute URL
+      return path;
+    }
+    let root = (<any>window).testApiUrl || this.apiUrl;
+
+    if(root) {
+      if(! root.endsWith('/')) root += '/';
+      return root + path;
+    }
+  }
+
+  get defaultTopicType(): string {
+    return this._defaultTopicType;
+  }
+
+  loadJson(url, params?: HttpParams) : Observable<Object> {
+    return this._http.get(url, {params})
+      .pipe(catchError(error => {
+        console.error("JSON load error", error);
+        return _throw(error);
+      }));
+  }
+
+  postJson(url, payload, params?: HttpParams) : Observable<Object> {
+    let headers = {'Content-Type': 'application/json'};
+    return this._http.post(url, JSON.stringify(payload), {headers, params})
+      .pipe(catchError(error => {
+        console.error("JSON load error", error);
+        return _throw(error);
+      }));
+  }
+
+  postParams(url, params: {[key: string]: string}|HttpParams) : Observable<Object> {
+    let body = this.makeHttpParams(params);
+    return this._http.post(url, body)
+      .pipe(catchError(error => {
+        console.error("JSON load error", error);
+        return _throw(error);
+      }));
+  }
+
+  loadFromApi(path: string, params?: HttpParams) : Observable<Object> {
+    let url = this.getRequestUrl(path);
+    if(url) {
+      return this.loadJson(url, params);
+    }
+  }
+
+  quickLoad(force?) {
+    return new Promise((resolve, reject) => {
+      if(this._quickLoaded && !force) {
+        resolve(1);
+        return;
+      }
+      let baseurl = this.getRequestUrl('');
+      console.log('base url: ' + baseurl);
+      if(! baseurl) {
+        reject("Base URL not defined");
+        return;
+      }
+      let req = this._http.get(baseurl + 'quickload')
+        .pipe(catchError(error => {
+          console.error(error);
+          return _throw(error);
+        }));
+      req.subscribe((data: any) => {
+        if(data.counts) {
+          for (let k in data.counts) {
+            this._recordCounts[k] = parseInt(data.counts[k]);
+          }
+        }
+        if(data.credential_counts) {
+          for (let k in data.credential_counts) {
+            this._recordCounts[k] = parseInt(data.credential_counts[k]);
+          }
+        }
+        if(data.records) {
+          for (let k in data.records) {
+            this._orgData[k] = data.records[k];
+          }
+        }
+        this._quickLoaded = true;
+        resolve(1);
+      }, err => {
+        reject(err);
+      });
+    });
+  }
+
+  getRecordCount (type) {
+    return this._recordCounts[type] || 0;
+  }
+
+  autocomplete (term) : Observable<Object> {
+    if(term === '' || typeof(term) !== 'string') {
+      return of([]);
+    }
+    let params = new HttpParams().set('q', term);
+    return this.loadFromApi('search/autocomplete', params)
+      .pipe(map(response => {
+        let ret = [];
+        for(let row of response['results']) {
+          let found = null;
+          for(let name of row.names) {
+            if(~ name.text.toLowerCase().indexOf(term.toLowerCase())) {
+              found = name.text;
+              break;
+            } else if(found === null) {
+              found = name.text;
+            }
+          }
+          if(found !== null) {
+            ret.push({id: row.id, term: found});
+          }
+        }
+        return ret;
+      }));
+  }
+
+  makeHttpParams(query?: { [key: string ]: string } | HttpParams) {
+    let httpParams: HttpParams;
+    if(query instanceof HttpParams) {
+      httpParams = query;
+    } else {
+      httpParams = new HttpParams();
+      if(query) {
+        for(let k in query) {
+          httpParams = httpParams.set(k, query[k]);
+        }
+      }
+    }
+    return httpParams;
+  }
+
+  fixRecordId (id: number | string) {
+    if(typeof id === 'number')
+      id = ''+id;
+    return id;
+  }
+
+  loadRecord <T>(
+      fetch: Fetch.DataLoader<T>,
+      id: string | number,
+      params?: { [key: string ]: any }) {
+    if(! params) params = {};
+    let path = params.path || fetch.request.getRecordPath(
+      this.fixRecordId(id), this.fixRecordId(params.childId), params.extPath);
+    return this.loadData(fetch, path, params);
+  }
+
+  loadList <T>(fetch: Fetch.ListLoader<T>, params?: { [key: string ]: any }) {
+    if(! params) params = {};
+    let path = params.path || fetch.request.getListPath(params.parentId, params.extPath);
+    return this.loadData(fetch, path, params);
+  }
+
+  loadAll <M extends Model.BaseModel>(
+      ctor: Model.ModelCtor<M>): Promise<M[]> {
+    let loader = new Fetch.ModelListLoader<M>(ctor);
+    let allRows: M[] = [];
+    return new Promise((resolve, fail) => {
+      loader.stream.subscribe(result => {
+        // FIXME - implement pagination
+        if(result.loaded) {
+          allRows = allRows.concat(result.data);
+          resolve(allRows);
+        }
+      });
+      this.loadList(loader);
+    });
+  }
+
+  loadData <T, R extends Fetch.BaseResult<T>>(fetch: Fetch.BaseLoader<T,R>, path: string, params?: { [key: string ]: any }) {
+    if(! params) params = {};
+    if(! path)
+      // fetch.loadNotFound
+      fetch.loadError("Undefined resource path");
+    else {
+      let httpParams = this.makeHttpParams(params.query);
+      let url = this.getRequestUrl(path);
+      if(params.primary) {
+        if(this._loaderSub)
+          this._loaderSub.unsubscribe();
+        this._loaderSub = fetch.stream.subscribe((result) => {
+          this.setCurrentResult(result);
+        });
+      }
+      fetch.loadFrom(this.loadJson(url, httpParams), {url: url});
+    }
+  }
+
+  onCurrentResult(sub): Subscription {
+    return this._currentResultSubj.subscribe(sub);
+  }
+
+  setCurrentResult(result: Fetch.BaseResult<any>) {
+    this._currentResultSubj.next(result);
+  }
+
+  deleteRecord (mod: string, id: string) {
+    return new Promise(resolve => {
+      let baseurl = this.getRequestUrl(mod + '/' + id + '/delete');
+      let req = this._http.post(baseurl, {params: {id}})
+        .pipe(catchError(error => {
+          console.error(error);
+          resolve(null);
+          return _throw(error);
+        }));
+      req.subscribe(data => {
+        console.log('delete result', data);
+        resolve(data);
+      });
+    });
+  }
+
+}

--- a/dflow-demo/src/environments/environment.prod.ts
+++ b/dflow-demo/src/environments/environment.prod.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: true,
-  API_URL: "https://devex-von-permitify-dev.pathfinder.gov.bc.ca/bc-tob/"
+  API_URL: "/bc-tob/"
 };

--- a/dflow-demo/src/environments/environment.prod.ts
+++ b/dflow-demo/src/environments/environment.prod.ts
@@ -1,3 +1,4 @@
 export const environment = {
-  production: true
+  production: true,
+  API_URL: "https://devex-von-permitify-dev.pathfinder.gov.bc.ca/bc-tob/"
 };

--- a/dflow-demo/src/environments/environment.ts
+++ b/dflow-demo/src/environments/environment.ts
@@ -4,7 +4,7 @@
 
 export const environment = {
   production: false,
-  API_URL: "http://localhost:5000/bc-tob/"
+  API_URL: "/bc-tob/"
 };
 
 /*

--- a/dflow-demo/src/environments/environment.ts
+++ b/dflow-demo/src/environments/environment.ts
@@ -3,7 +3,8 @@
 // The list of file replacements can be found in `angular.json`.
 
 export const environment = {
-  production: false
+  production: false,
+  API_URL: "http://localhost:5000/bc-tob/"
 };
 
 /*


### PR DESCRIPTION
Added support for searching an existing legal entity in the initial step of the demo, using a typeahead search box that queries ToB.
![image](https://user-images.githubusercontent.com/2395873/49620812-683c3200-f977-11e8-979a-284118424456.png)
The code was pulled from `tob-web`, with some minor customizations to match the data types.

Additional tweaks were implemented to ensure credentials are issuable by both using the agent form, and using the API endpoint. This was obtained by removing the `connection_id` parameter in the agent configuration (`service.yml`) and ensuring the service name matches the routes used by Caddy to proxy the requests.

Added link to home for ease of navigation.
