### PR TITLE
Added support for credential-specific URLs

### DIFF
--- a/dflow-demo/src/app/components/workflow/workflow-step/workflow-step.component.ts
+++ b/dflow-demo/src/app/components/workflow/workflow-step/workflow-step.component.ts
@@ -42,7 +42,7 @@ export class WorkflowStepComponent implements OnInit {
       this.actionTxt = `Enroll with ${this.step.issuer.name}`;
       const credentialParam = `credential_ids=${this.step.walletId}`;
       const schemaParam = `schema_name=${this.step.requestedSchema.name}&schema_version=${this.step.requestedSchema.version}&issuer_did=${this.step.requestedSchema.did}`;
-      this.actionURL = `${this.step.issuer.url}?${credentialParam}&${schemaParam}`;
+      this.actionURL = `${this.step.actionURL}?${credentialParam}&${schemaParam}`;
       this.actionTarget = '_self'
     } else {
       this.actionTxt = 'Dependencies not met';

--- a/dflow-demo/src/app/models/step.ts
+++ b/dflow-demo/src/app/models/step.ts
@@ -13,10 +13,10 @@ export class Step {
   walletId: string;
   // TODO: refactor requestedschema out of the step, if possible
   requestedSchema: any;
+  actionURL: string;
 
   // computed
   actionText: string;
-  actionURL: string;
 
   constructor ( stepData: any ) {
       this.topicId = stepData.topicId;
@@ -28,6 +28,7 @@ export class Step {
         this.credentialId = stepData.credData.id;
         this.effectiveDate = stepData.credData.effective_date;
       }
+      this.actionURL = stepData.schemaURL;
 
       this.requestedSchema = {
         name: '',

--- a/dflow-demo/src/app/services/tob.service.ts
+++ b/dflow-demo/src/app/services/tob.service.ts
@@ -56,6 +56,14 @@ export class TobService {
   }
 
   /**
+   * Restirns a JSON structure representing the details for the credentials registered in ToB.
+   */
+  getCredentialTypes() {
+    const reqURL = '/bc-tob/credentialtype?inactive=false&latest=true&revoked=false';
+    return this.http.get(reqURL);
+  }
+
+  /**
    * Returns a JSON structure representing the list of steps obtained by the topic (e.g.: Incorporated Company)
    * @param topicId the id of the topic being requested
    */


### PR DESCRIPTION
Addresses #158 by retrieving the credential-specific URL for each step in dFlow, by querying the `/credentialtype` API endpoint exposed by ToB.